### PR TITLE
Actualizo los docker para que se conecten entre si al correr las pruebas de integración

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ ./run-acceptance-tests.sh
 Ejemplo de uso descargando sólo los repositorios de App server y Media server:
 
 ```bash
-$ ./run-acceptance-tests.sh --chotuve-auth-server=../chotuve-auth-server
+$ ./run-acceptance-tests.sh --chotuve-auth-repo=../chotuve-auth-server
 ```
 
 ## Correr las pruebas (indicando URL)

--- a/features/steps/test-steps.py
+++ b/features/steps/test-steps.py
@@ -13,4 +13,4 @@ def step_impl(context, titulo):
 
 @then('obtiene una respuesta exitosa')
 def step_impl(context):
-    assert context.response.status_code == 201
+    assert context.response.status_code == 201, f'Código de retorno incorrecto: {context.response.status_code}'

--- a/run-acceptance-tests.sh
+++ b/run-acceptance-tests.sh
@@ -52,6 +52,10 @@ case $arg in
         export CHOTUVE_AUTH_REPO_DIR=$(readlink -f "${arg#*=}")
     shift
     ;;
+    --no-docker-for-behave)
+        export NO_DOCKER_FOR_BEHAVE=1
+    shift
+    ;;
     *)
          print_usage;
          exit 1;
@@ -182,13 +186,17 @@ if [[ ! $CHOTUVE_APP_URL ]]; then
 fi
 
 echo 'Corriendo behave...'
-docker run -it --network="host" \
-    -e CHOTUVE_MEDIA_URL=$CHOTUVE_MEDIA_URL \
-    -e CHOTUVE_APP_URL=$CHOTUVE_APP_URL \
-    -e CHOTUVE_AUTH_URL=$CHOTUVE_AUTH_URL \
-    -v $ACCEPTANCE_TESTS_DIR:/tests \
-    -w /tests \
-    python:3.8 \
-    sh -c 'pip install -r requirements.txt && behave'
-
+if [[ ! $NO_DOCKER_FOR_BEHAVE ]]; then
+    docker run -it --network="host" \
+        -e CHOTUVE_MEDIA_URL=$CHOTUVE_MEDIA_URL \
+        -e CHOTUVE_APP_URL=$CHOTUVE_APP_URL \
+        -e CHOTUVE_AUTH_URL=$CHOTUVE_AUTH_URL \
+        -v $ACCEPTANCE_TESTS_DIR:/tests \
+        -w /tests \
+        python:3.8 \
+        sh -c 'pip install -r requirements.txt && behave'
+else
+    cd $ACCEPTANCE_TESTS_DIR
+    behave
+fi
 # La limpieza se hace automáticamente antes de que termine el proceso de bash

--- a/run-acceptance-tests.sh
+++ b/run-acceptance-tests.sh
@@ -16,12 +16,12 @@ REPO_CHOTUVE_APP="https://github.com/taller2fiuba/chotuve-app-server"
 REPO_CHOTUVE_AUTH="https://github.com/taller2fiuba/chotuve-auth-server"
 
 function print_usage() {
-    echo "Corre las pruebas de aceptación."
-    echo "Uso: $0 [--chotuve-media-repo=<MEDIA REPO>] [--chotuve-app-repo=<APP REPO>] [--chotuve-auth-repo=<AUTH REPO>]"
-    echo "Si se le pasa --chotuve-media-repo y/o --chotuve-app-repo se utilizarán esas URLs para"
-    echo "contactar al servidor de Flask y Node, respectivamente."
-    echo "Si no se pasa alguno de esos parámetros el script levantará una imagen"
-    echo "productiva del servidor correspondiente mediante docker-compose".
+    echo "Levanta versiones productivas de los servidores y corre las pruebas de aceptación."
+    echo "Uso: $0 [OPCIONES]"
+    echo "Opciones:"
+    echo '  --chotuve-[app|auth|media]-repo=<directorio>: Ubicación del repositorio para un servidor.'
+    echo '      Si no se pasa esta opción para alguno de los servidores, se lo clonará desde su repositorio.'
+    echo '  --no-docker-for-behave: Corre behave en la máquina local en lugar de hacerlo dentro de un contenedor de Docker.'
 }
 
 # Procesar argumentos

--- a/run-tests-url.sh
+++ b/run-tests-url.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+function print_usage() {
+    echo "Corre las pruebas de aceptación sin levantar ningún servidor."
+    echo "Uso: $0 [OPCIONES]"
+    echo "Opciones:"
+    echo '  --chotuve-[app|auth|media]-url=<URL>: Requerido. URL de cada servidor.'
+    echo '  --no-docker-for-behave: Corre behave en la máquina local en lugar de hacerlo dentro de un contenedor de Docker.'
+}
+
+# Procesar argumentos
+for arg in "$@"
+do
+case $arg in
+    --chotuve-media-url=*)
+        export CHOTUVE_MEDIA_URL="${arg#*=}"
+    shift
+    ;;
+    --chotuve-app-url=*)
+        export CHOTUVE_APP_URL="${arg#*=}"
+    shift
+    ;;
+    --chotuve-auth-url=*)
+        export CHOTUVE_AUTH_URL="${arg#*=}"
+    shift
+    ;;
+    --no-docker-for-behave)
+        export NO_DOCKER_FOR_BEHAVE=1
+    shift
+    ;;
+    *)
+         print_usage;
+         exit 1;
+    ;;
+esac
+done
+
+if [[ ! $CHOTUVE_MEDIA_URL ]]; then
+    echo 'La URL para Chotuve Media es un parámetro requerido.'
+    exit 1
+fi
+
+if [[ ! $CHOTUVE_AUTH_URL ]]; then
+    echo 'La URL para Chotuve Auth es un parámetro requerido.'
+    exit 1
+fi
+
+if [[ ! $CHOTUVE_APP_URL ]]; then
+    echo 'La URL para Chotuve App es un parámetro requerido.'
+    exit 1
+fi
+
+set -e
+
+ACCEPTANCE_TESTS_DIR=$(readlink -f $(dirname $0))
+
+echo 'Corriendo behave...'
+if [[ ! $NO_DOCKER_FOR_BEHAVE ]]; then
+    docker run -it --network="host" \
+        -e CHOTUVE_MEDIA_URL=$CHOTUVE_MEDIA_URL \
+        -e CHOTUVE_APP_URL=$CHOTUVE_APP_URL \
+        -e CHOTUVE_AUTH_URL=$CHOTUVE_AUTH_URL \
+        -v $ACCEPTANCE_TESTS_DIR:/tests \
+        -w /tests \
+        python:3.8 \
+        sh -c 'pip install -r requirements.txt && behave'
+else
+    cd $ACCEPTANCE_TESTS_DIR
+    behave
+fi
+# La limpieza se hace automáticamente antes de que termine el proceso de bash


### PR DESCRIPTION
- Ahora hay dos scripts: uno para correr `behave` pasandole URLs (para dev) y otro pasandole repositorios (para prod).
- Todos los docker-compose deben poder estar dentro de una red de Docker llamada `chotuve`
- Se agregó una opción para correr `behave` en la máquina local (y no dentro de Docker) para que sea más rápido.